### PR TITLE
Fix issue with misdetection of existing ssh agent

### DIFF
--- a/.bash-config/.ssh-config
+++ b/.bash-config/.ssh-config
@@ -42,9 +42,12 @@ else
   if [ -f "$SSH_ENV" ]; then
     . "$SSH_ENV" > /dev/null
   fi
-  ps -ef | grep "$SSH_AGENT_PID" | grep ssh-agent > /dev/null
-  if [ $? -eq 0 ]; then
-    test_identities
+  
+  if [ -n "$SSH_AGENT_PID" ]; then
+    ps -ef | grep "$SSH_AGENT_PID" | grep ssh-agent > /dev/null
+    if [ $? -eq 0 ]; then
+      test_identities
+    fi
   else
     start_agent
   fi


### PR DESCRIPTION
Given the following situation: there is no file at ~/.ssh/environment and
the SSH_AGENT_PID variable is not set, but there are ssh-agents running
from other bash sessions (started manually and not via the start_agent method).

In this case, checking for running SSH agents (ps -ef | grep ...) will return
a zero exit code because there are ssh-agents running. Thus, test_identities
will be called which, however, is failing because in the current session, no
ssh-agent is running.

This fix solves the problem by verifying that the SSH_AGENT_PID variable is
set after reading ~/.ssh/environment.