### PR TITLE
Lazy evaluate 'git rev-list' command

### DIFF
--- a/.bash-config/.alias-config
+++ b/.bash-config/.alias-config
@@ -201,7 +201,7 @@ alias spa=$STASH_PULL_APPLY
 TAGS="git tag --list"
 alias tags=$TAGS
 
-LATEST_TAG="git describe --tags $(git rev-list --tags --max-count=1)"
+LATEST_TAG="git describe --tags \$(git rev-list --tags --max-count=1)"
 alias tag=$LATEST_TAG
 
 


### PR DESCRIPTION
The 'git rev-list' command within the 'LATEST_TAG' variable has to be
escaped so that it is executed when the alias 'tag' is called, not when
the string is created. Therefore, we escape the dollar sign.